### PR TITLE
Base CI Pipeline

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,35 @@
+name: CI
+# execute on a push or pull request
+on:
+  - push
+  - pull_request
+
+jobs:
+  pre_job: 
+    runs-on: [ubuntu-latest]
+    # taken from Bloqade.jl CI.yaml
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+
+  # taken from example on julia-actions/runtest@v1
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1','1.6']
+        julia-arch: x64
+        os: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          annotate: true


### PR DESCRIPTION
Should allow for package unit tests to be run whenever anything is pushed to main or a pull request is made. Currently single threaded, will probably require setting the right environment vars to enable multithreading tests