### PR TITLE
Fix Duplicate Actions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
+        with:
+          paths_ignore: '["**/README.md"]'
 
   # taken from example on julia-actions/runtest@v1
   test:


### PR DESCRIPTION
Original Workflow YAML was missing the proper entries to skip an action if a duplicate was detected.
Rule has been added to skip actions on any changes to `README.md` files as well. 