### PR TITLE
Remove Atomix.jl as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,12 @@ uuid = "c4b929cc-6141-4ba4-8849-280a863346e1"
 version = "0.1.0"
 
 [deps]
-Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]

--- a/src/ParallelMergeCSR.jl
+++ b/src/ParallelMergeCSR.jl
@@ -1,6 +1,5 @@
 module ParallelMergeCSR
 
-using Atomix
 using Base.Threads
 using SparseArrays
 using LinearAlgebra: Adjoint,adjoint,Transpose,transpose


### PR DESCRIPTION
Remnant from when `mul!` had a base CSC-handling representation, no longer used in the main `mul!` implementation