### PR TITLE
Fix Codecov Failure

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -48,4 +48,5 @@ jobs:
         if: ${{matrix.julia-num-threads == 8}}
         uses: "codecov/codecov-action@v3"
         with:
+          directory: ./src
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov will still say it ran successfully through Github actions but the output shows that it didn't even find coverage files. Explicitly directing it to the directory where the `.cov` files should remedy the problem. 