### PR TITLE
Add in-place tests for `merge_csr_mv!` function

### DIFF
--- a/test/merge_csr_mv!.jl
+++ b/test/merge_csr_mv!.jl
@@ -20,7 +20,9 @@ using SparseArrays: sprand, sparse
 end
 
 @testset "Extreme Cases" begin
+
     @testset "Singleton (Real)" begin
+    
         A = sparse(reshape([1], 1, 1))
 
         x = rand(1)
@@ -30,10 +32,12 @@ end
 
         merge_csr_mv!(0.3, A, x, y, transpose)
 
-        @test (A * x * 0.3) + y_original == y
+        @test (A * x * 0.3) + y_original ≈ y
+
     end
 
     @testset "Singleton (Complex)" begin
+    
         A = sparse(reshape([1.0+2.5im], 1, 1))
 
         x = rand(1)
@@ -43,7 +47,8 @@ end
 
         merge_csr_mv!(10.1, A, x, y, adjoint)
 
-        @test (adjoint(Matrix(A)) * x * 10.1) + y_original == y
+        @test (adjoint(Matrix(A)) * x * 10.1) + y_original ≈ y
+
     end
 
     @testset "Single row (Real)" begin
@@ -60,6 +65,7 @@ end
         merge_csr_mv!(1.1, A, x, y, transpose)
 
         @test ((transpose(A) * x) * 1.1) + y_original ≈ y
+
     end
 
     @testset "Single row (Complex)" begin
@@ -75,6 +81,7 @@ end
         merge_csr_mv!(1.1, A, x, y, transpose)
 
         @test ((transpose(A) * x) * 1.1) + y_original ≈ y
+
     end
 
 
@@ -92,6 +99,7 @@ end
 end
 
 @testset "Square (Real)" begin
+
     A = sprand(10,10,0.3)
 
     # 10 x 1
@@ -108,6 +116,7 @@ end
 end
 
 @testset "Square (Complex)" begin
+
     A = sprand(Complex{Float64}, 10, 10, 0.3)
 
     x = 10 * rand(Complex{Float64}, 10)
@@ -118,6 +127,7 @@ end
     merge_csr_mv!(1.1, A, x, y, adjoint)
 
     @test ((adjoint(A) * x) * 1.1) + y_original ≈ y
+
 end
 
 @testset "4x6 (Real)" begin
@@ -140,7 +150,8 @@ end
     # multiply
     merge_csr_mv!(2.0, A, x, y, adjoint)
 
-    @test (adjoint(m) * x * 2.0) + y_original == y
+    @test (adjoint(m) * x * 2.0) + y_original ≈ y
+
 end
 
 @testset "4 x 6 (Complex)" begin
@@ -163,7 +174,7 @@ end
     # multiply
     merge_csr_mv!(2.0, A, x, y, adjoint)
 
-    @test (adjoint(m) * x * 2.0) + y_original == y
+    @test (adjoint(m) * x * 2.0) + y_original ≈ y
 
 end
 
@@ -181,6 +192,7 @@ end
     merge_csr_mv!(3.0, A, x, y, transpose)
 
     @test (transpose(A) * x * 3) + y_original ≈ y
+
 end
 
 @testset "100x100 (Complex)" begin
@@ -197,6 +209,7 @@ end
     merge_csr_mv!(3.0, A, x, y, transpose)
 
     @test (transpose(A) * x * 3) + y_original ≈ y
+
 end
 
 #=

--- a/test/mul!.jl
+++ b/test/mul!.jl
@@ -18,6 +18,7 @@ using SparseArrays
         ParallelMergeCSR.mul!(C, A, B, α, β)
         SparseArrays.mul!(C_copy, A, B, α, β)
         @test C ≈ C_copy
+
     end
 
     @testset "Adjoint Complex Matrix" begin
@@ -51,6 +52,7 @@ using SparseArrays
         ParallelMergeCSR.mul!(C, A, B, α, β)
         SparseArrays.mul!(C_copy, A, B, α, β)
         @test C ≈ C_copy
+
     end
 
     @testset "Transpose Complex Matrix" begin
@@ -66,7 +68,9 @@ using SparseArrays
         ParallelMergeCSR.mul!(C, A, B, α, β)
         SparseArrays.mul!(C_copy, A, B, α, β)
         @test C ≈ C_copy
+        
     end
+
 end
 
 # trigger merge_csr_mv! in this repo, does not default to mul! somewhere else
@@ -121,7 +125,6 @@ end
         SparseArrays.mul!(C_copy, A, B, α, β)
         @test C ≈ C_copy
 
-    
     end
 
     @testset "Transpose Square Complex" begin
@@ -137,6 +140,7 @@ end
         ParallelMergeCSR.mul!(C, A, B, α, β)
         SparseArrays.mul!(C_copy, A, B, α, β)
         @test C ≈ C_copy
+
     end
 
     @testset "Transpose Rectangular Real" begin
@@ -172,4 +176,5 @@ end
         @test C ≈ C_copy
     
     end
+
 end


### PR DESCRIPTION
`merge_csr_mv!` has the ability to add the result to the output vector that is passed in (versus just assigning values to it) but this wasn't explicitly tested by the `merge_csr_mv!` specific unit tests.

Unit tests now use `rand` instead of `zeros` to generate the `y`/`input` vector. 