### PR TITLE
Updated checkout action in CI to v3 from v2

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Setup Julia"
         uses: julia-actions/setup-julia@v1
         with:


### PR DESCRIPTION
Warnings were being issued about Node JS 12 actions being deprecated from using `actions/checkout@v2` prompting upgraded to v3