### PR TITLE
Test Beta Special Cases

### DIFF
--- a/test/mul!.jl
+++ b/test/mul!.jl
@@ -213,4 +213,5 @@ end
         SparseArrays.mul!(C_copy, A, B, α, β)
         @test C == C_copy
     end
-begin
+
+end


### PR DESCRIPTION
When the beta coefficient is either 0 or 1 there is some additional logic `mul!` uses to prevent invoking unnecessary multiplication of the coefficient against the `output` vectors pre-existing values. 

This wasn't explicitly tested but this PR implements that. Credit to @weinbe58 for the idea.