### PR TITLE
Remove unnecessary codecov token

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -53,4 +53,3 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Now that the repository is public the token is unnecessary (and may be causing some current issues with coverage by keeping it around)