### PR TITLE
Added three day merge notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ ParallelMergeCSR only exports one function: `mul!` which is used for both Sparse
 
 ## Installation
 
-Enter the Julia Package Manager and install via:
+### NOTICE
+It will take *three days* before this package becomes part of the Julia registry meaning the instructions below will only work after those three days have elapsed.
 
-```
-pkg> add ParallelMergeCSR
-```
+To circumvent this, you can go into the Julia Package Manager and perform `add` with the URL of this repository.
 
 ## Usage
 


### PR DESCRIPTION
Due to the mandatory waiting period, a notice should be put up directing users to use `add` in the package manager in conjunction with the Github URL over the name of the package itself.