### PR TITLE
lower Julia compatibility threshold

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         julia-num-threads: [1,2,4,8]
-        julia-version: ['1.8']
+        julia-version: ['1.6']
         julia-arch: [x64]
         os: [ubuntu-latest]
     #1, 2, 4, 8 thread test

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Polyester = "0.7.2"
-julia = "1.8"
+Polyester = "0.7.3"
+julia = "1.6"
 
 [extras]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"


### PR DESCRIPTION
Allows this package to be compatible with BloqadeExpr, current 1.8 requirement causing compatibility issues. 